### PR TITLE
a feature to set debug mode

### DIFF
--- a/eventlog_windows.go
+++ b/eventlog_windows.go
@@ -20,35 +20,34 @@ type windowsLogger struct {
 	d bool
 }
 
-func (w windowsLogger) Debug(format string, v ...interface{}) {
+func (w windowsLogger) debug(format string, v ...interface{}) {
 	if w.d {
 		w.w.Info(1001, fmt.Sprintf(format, v...))
 	}
 }
 
-func (w windowsLogger) Info(format string, v ...interface{}) {
+func (w windowsLogger) info(format string, v ...interface{}) {
 	w.w.Info(1001, fmt.Sprintf(format, v...))
 }
 
-func (w windowsLogger) Warning(format string, v ...interface{}) {
+func (w windowsLogger) warning(format string, v ...interface{}) {
 	w.w.Warning(2001, fmt.Sprintf(format, v...))
 }
 
-func (w windowsLogger) Err(format string, v ...interface{}) {
+func (w windowsLogger) err(format string, v ...interface{}) {
 	w.w.Error(3001, fmt.Sprintf(format, v...))
 }
 
-func (w windowsLogger) Crit(format string, v ...interface{}) {
+func (w windowsLogger) crit(format string, v ...interface{}) {
 	w.w.Error(4001, fmt.Sprintf(format, v...))
 	os.Exit(2)
 }
 
-// SetDebug can enable/disable debug mode.
-func (w *windowsLogger) SetDebug(status bool) {
+func (w *windowsLogger) setDebug(status bool) {
 	w.d = status
 }
 
-func NewLogger(f Facility, tag string, debug bool, addr ...string) (logger Logger, err error) {
+func newLogger(f Facility, tag string, debug bool, addr ...string) (logger Logger, err error) {
 	var w *eventlog.Log
 	if len(addr) > 0 {
 		err = errors.New("not implemented")

--- a/eventlog_windows.go
+++ b/eventlog_windows.go
@@ -43,6 +43,11 @@ func (w windowsLogger) Crit(format string, v ...interface{}) {
 	os.Exit(2)
 }
 
+// SetDebug can enable/disable debug mode.
+func (w *windowsLogger) SetDebug(status bool) {
+	w.d = status
+}
+
 func NewLogger(f Facility, tag string, debug bool, addr ...string) (logger Logger, err error) {
 	var w *eventlog.Log
 	if len(addr) > 0 {
@@ -50,5 +55,5 @@ func NewLogger(f Facility, tag string, debug bool, addr ...string) (logger Logge
 	} else {
 		w, err = eventlog.Open(tag)
 	}
-	return windowsLogger{w: w, d: debug}, err
+	return &windowsLogger{w: w, d: debug}, err
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/lufia/netlog
 
 go 1.13
 
-require golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e
+require golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e h1:LwyF2AFISC9nVbS6MgzsaQNSUsRXI49GS+YQ5KX/QH0=
-golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e h1:NHvCuwuS43lGnYhten69ZWqi2QOj/CiDNcKbVqwVoew=
+golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/netlog.go
+++ b/netlog.go
@@ -150,22 +150,41 @@ func SetOutputURL(s string, debug ...bool) (err error) {
 	}
 }
 
+// Debug outputs debug level log output.
+// It is usually used to output detailed debug information.
+// If debug status is not enabled, no output is generated.
+// This log level need not be treated as an anomaly.
+// The debug status can be set from SetDebug.
 func Debug(format string, v ...interface{}) {
 	DefaultLogger.Debug(format, v...)
 }
 
+// Info outputs information level log output.
+// It is usually used to output interesting events.
+// This log level need not be treated as an anomaly.
 func Info(format string, v ...interface{}) {
 	DefaultLogger.Info(format, v...)
 }
 
+// Warning outputs warning level log output.
+// It is usually used to output exceptional occurrences that are not errors.
+// This log level need not be treated as an anomaly.
 func Warning(format string, v ...interface{}) {
 	DefaultLogger.Warning(format, v...)
 }
 
+// Err outputs error level log output.
+// It is usually used to output execution-time errors that do not require
+// immediate action but should typically be logged and monitored.
+// This log level need be treated as an anomaly.
 func Err(format string, v ...interface{}) {
 	DefaultLogger.Err(format, v...)
 }
 
+// Crit outputs critical level log output.
+// It is usually used to output critical conditions.
+// When this method is executed, the process abends after outputting the log.
+// This log level need be treated as an anomaly.
 func Crit(format string, v ...interface{}) {
 	DefaultLogger.Crit(format, v...)
 }

--- a/netlog.go
+++ b/netlog.go
@@ -10,14 +10,12 @@ import (
 )
 
 type Logger interface {
-	Debug(format string, v ...interface{})
-	Info(format string, v ...interface{})
-	Warning(format string, v ...interface{})
-	Err(format string, v ...interface{})
-	Crit(format string, v ...interface{})
-
-	// SetDebug can enable/disable debug mode.
-	SetDebug(bool)
+	debug(format string, v ...interface{})
+	info(format string, v ...interface{})
+	warning(format string, v ...interface{})
+	err(format string, v ...interface{})
+	crit(format string, v ...interface{})
+	setDebug(bool)
 }
 
 const (
@@ -75,31 +73,30 @@ func (c consoleLogger) print(format string, v ...interface{}) {
 	}
 }
 
-func (c consoleLogger) Debug(format string, v ...interface{}) {
+func (c consoleLogger) debug(format string, v ...interface{}) {
 	if c.d {
 		c.print(logHeaderDebug+format, v...)
 	}
 }
 
-func (c consoleLogger) Info(format string, v ...interface{}) {
+func (c consoleLogger) info(format string, v ...interface{}) {
 	c.print(logHeaderInfo+format, v...)
 }
 
-func (c consoleLogger) Warning(format string, v ...interface{}) {
+func (c consoleLogger) warning(format string, v ...interface{}) {
 	c.print(logHeaderWarning+format, v...)
 }
 
-func (c consoleLogger) Err(format string, v ...interface{}) {
+func (c consoleLogger) err(format string, v ...interface{}) {
 	c.print(logHeaderErr+format, v...)
 }
 
-func (c consoleLogger) Crit(format string, v ...interface{}) {
+func (c consoleLogger) crit(format string, v ...interface{}) {
 	c.print(logHeaderCrit+format, v...)
 	os.Exit(2)
 }
 
-// SetDebug can enable/disable debug mode.
-func (c *consoleLogger) SetDebug(status bool) {
+func (c *consoleLogger) setDebug(status bool) {
 	c.d = status
 }
 
@@ -136,11 +133,11 @@ func SetOutputURL(s string, debug ...bool) (err error) {
 		return nil
 	case "net":
 		// net:///?facility=x&tag=x
-		DefaultLogger, err = NewLogger(facility, tag, isDebug)
+		DefaultLogger, err = newLogger(facility, tag, isDebug)
 		return
 	case "tcp":
 		// tcp://localhost:port/?facility=x&tag=x
-		DefaultLogger, err = NewLogger(facility, tag, isDebug, u.Host)
+		DefaultLogger, err = newLogger(facility, tag, isDebug, u.Host)
 		return
 	case "tcp4", "tcp6":
 		return errors.New("not implemented")
@@ -156,21 +153,21 @@ func SetOutputURL(s string, debug ...bool) (err error) {
 // This log level need not be treated as an anomaly.
 // The debug status can be set from SetDebug.
 func Debug(format string, v ...interface{}) {
-	DefaultLogger.Debug(format, v...)
+	DefaultLogger.debug(format, v...)
 }
 
 // Info outputs information level log output.
 // It is usually used to output interesting events.
 // This log level need not be treated as an anomaly.
 func Info(format string, v ...interface{}) {
-	DefaultLogger.Info(format, v...)
+	DefaultLogger.info(format, v...)
 }
 
 // Warning outputs warning level log output.
 // It is usually used to output exceptional occurrences that are not errors.
 // This log level need not be treated as an anomaly.
 func Warning(format string, v ...interface{}) {
-	DefaultLogger.Warning(format, v...)
+	DefaultLogger.warning(format, v...)
 }
 
 // Err outputs error level log output.
@@ -178,7 +175,7 @@ func Warning(format string, v ...interface{}) {
 // immediate action but should typically be logged and monitored.
 // This log level need be treated as an anomaly.
 func Err(format string, v ...interface{}) {
-	DefaultLogger.Err(format, v...)
+	DefaultLogger.err(format, v...)
 }
 
 // Crit outputs critical level log output.
@@ -186,10 +183,10 @@ func Err(format string, v ...interface{}) {
 // When this method is executed, the process abends after outputting the log.
 // This log level need be treated as an anomaly.
 func Crit(format string, v ...interface{}) {
-	DefaultLogger.Crit(format, v...)
+	DefaultLogger.crit(format, v...)
 }
 
 // SetDebug can enable/disable debug mode.
 func SetDebug(state bool) {
-	DefaultLogger.SetDebug(state)
+	DefaultLogger.setDebug(state)
 }

--- a/syslog_unix.go
+++ b/syslog_unix.go
@@ -43,6 +43,11 @@ func (w unixLogger) Crit(format string, v ...interface{}) {
 	os.Exit(2)
 }
 
+// SetDebug can enable/disable debug mode.
+func (w *unixLogger) SetDebug(status bool) {
+	w.d = status
+}
+
 func NewLogger(f Facility, tag string, debug bool, addr ...string) (logger Logger, err error) {
 	var w *syslog.Writer
 	if len(addr) > 0 {
@@ -50,5 +55,5 @@ func NewLogger(f Facility, tag string, debug bool, addr ...string) (logger Logge
 	} else {
 		w, err = syslog.New(syslog.Priority(f), tag)
 	}
-	return unixLogger{w: w, d: debug}, err
+	return &unixLogger{w: w, d: debug}, err
 }

--- a/syslog_unix.go
+++ b/syslog_unix.go
@@ -20,35 +20,34 @@ type unixLogger struct {
 	d bool
 }
 
-func (w unixLogger) Debug(format string, v ...interface{}) {
+func (w unixLogger) debug(format string, v ...interface{}) {
 	if w.d {
 		w.w.Debug(fmt.Sprintf(format, v...))
 	}
 }
 
-func (w unixLogger) Info(format string, v ...interface{}) {
+func (w unixLogger) info(format string, v ...interface{}) {
 	w.w.Info(fmt.Sprintf(format, v...))
 }
 
-func (w unixLogger) Warning(format string, v ...interface{}) {
+func (w unixLogger) warning(format string, v ...interface{}) {
 	w.w.Warning(fmt.Sprintf(format, v...))
 }
 
-func (w unixLogger) Err(format string, v ...interface{}) {
+func (w unixLogger) err(format string, v ...interface{}) {
 	w.w.Err(fmt.Sprintf(format, v...))
 }
 
-func (w unixLogger) Crit(format string, v ...interface{}) {
+func (w unixLogger) crit(format string, v ...interface{}) {
 	w.w.Crit(fmt.Sprintf(format, v...))
 	os.Exit(2)
 }
 
-// SetDebug can enable/disable debug mode.
-func (w *unixLogger) SetDebug(status bool) {
+func (w *unixLogger) setDebug(status bool) {
 	w.d = status
 }
 
-func NewLogger(f Facility, tag string, debug bool, addr ...string) (logger Logger, err error) {
+func newLogger(f Facility, tag string, debug bool, addr ...string) (logger Logger, err error) {
 	var w *syslog.Writer
 	if len(addr) > 0 {
 		w, err = syslog.Dial("tcp", addr[0], syslog.Priority(f), tag)


### PR DESCRIPTION
# Issue.
Currently debug mode must be enabled from the `SetOutputURL` method to log output level.
The method is set with the log output destination at initialization and is assumed to be executed only once.
The following problems exist due to this behavior.
* The `Debug` logs cannot be output if no output destination is specified.
* Cannot enable debug mode dynamically during process execution to output debug log.

# Changes
* Newly defined the `SetDebug` method.
    * Debug mode can be changed from the method.
* Changed methods that do not need to be public to private.
* Changed the description that doesn't fit the golang format.
    * Changed from SNAKE_CASE to CamelCase.
* Added some comments.